### PR TITLE
Output a clean error message when the port is in use

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,16 @@ fn main() {
 
     // Start the web server.
     let addr = format!("{}:{}", host, port);
-    HttpServer::new(app).bind(addr).unwrap().run().unwrap();
+    match HttpServer::new(app).bind(addr) {
+        Ok(server) => {
+            server.run().unwrap();
+        }
+        Err(e) => {
+            error!("Failed to start web server on {}:{}", host, port);
+            error!("{}", e.to_string());
+            exit(1);
+        }
+    }
 }
 
 // Controller for the homepage.


### PR DESCRIPTION
Currently the web server panics with a backtrace if the port is in use. Let's output a clean error message.