### PR TITLE
Remove dependencies on `dotenv` and `time` crates

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -135,8 +135,11 @@ fn main() {
                         "HASHER_ITERATIONS environment variable should be an integer value.",
                     );
 
+                let database_url = env::var("DATABASE_URL")
+                    .expect_or_exit("DATABASE_URL environment variable is not set.");
+
                 db::user::create(
-                    &establish_connection(),
+                    &establish_connection(&database_url),
                     arguments.value_of("email").unwrap(),
                     arguments.value_of("password").unwrap(),
                     secret.as_str(),

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2018"
 argonautica = "~0.2"
 chrono = "~0.4"
 diesel = { version = "~1.4", features = ['chrono', 'postgres', 'r2d2'] }
-dotenv = "^0.15"
 log = "~0.4"
 r2d2 = "~0.8"
-time = "~0.1.42"
 validator = "~0.10"
+
+[dev-dependencies]
+dotenv = "^0.15"
+time = "~0.1.42"

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -5,17 +5,13 @@ extern crate log;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use std::env;
 use std::process::exit;
 
 mod schema;
 pub mod user;
 
 // Establishes a non-pooled database connection.
-pub fn establish_connection() -> PgConnection {
-    let database_url =
-        env::var("DATABASE_URL").expect("DATABASE_URL environment variable is not set.");
-
+pub fn establish_connection(database_url: &str) -> PgConnection {
     match PgConnection::establish(&database_url) {
         Ok(value) => value,
         Err(e) => {
@@ -36,4 +32,11 @@ fn import_env_vars() {
     // Populate environment variables from the `.env.dist` file. This file contains sane defaults
     // as a fallback.
     dotenv::from_filename(".env.dist").ok();
+}
+
+// Retrieves the database URL from the environment variables.
+#[cfg(test)]
+fn get_database_url() -> String {
+    import_env_vars();
+    std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable is not set.")
 }

--- a/db/src/user.rs
+++ b/db/src/user.rs
@@ -121,7 +121,7 @@ pub fn read(connection: &PgConnection, email: &str) -> Result<User, UserError> {
 mod tests {
     use super::*;
 
-    use crate::{establish_connection, import_env_vars};
+    use crate::{establish_connection, get_database_url};
 
     use argonautica::Verifier;
     use diesel::result::Error;
@@ -179,8 +179,7 @@ mod tests {
 
     #[test]
     fn test_create() {
-        import_env_vars();
-        let connection = establish_connection();
+        let connection = establish_connection(&get_database_url());
         let email = "test@example.com";
         let password = "mypass";
         let secret = "mysecret";
@@ -232,8 +231,7 @@ mod tests {
 
     #[test]
     fn test_read() {
-        import_env_vars();
-        let connection = establish_connection();
+        let connection = establish_connection(&get_database_url());
         let email = "test@example.com";
         let password = "mypass";
         let secret = "mysecret";


### PR DESCRIPTION
By injecting the database URL we can remove the dependency on `dotenv` from the `db` library. We will still need it for tests though.